### PR TITLE
Drop v11/v12, add TYPO3 v14 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "keywords": ["typo3", "cdn", "cloudflare", "cache", "purge"],
     "license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms-core": "^11.5 || ^12.4 || ^13.4 || ^14.0",
-        "php": "^8.0"
+        "typo3/cms-core": "^13.4 || ^14.0",
+        "php": "^8.2"
     },
     "extra": {
         "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["typo3", "cdn", "cloudflare", "cache", "purge"],
     "license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms-core": "^11.5 || ^12.4 || ^13.4",
+        "typo3/cms-core": "^11.5 || ^12.4 || ^13.4 || ^14.0",
         "php": "^8.0"
     },
     "extra": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,7 +18,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-14.99.99',
+            'typo3' => '13.4.0-14.99.99',
         ],
         'conflicts' => [
         ],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,7 +18,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '2.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-13.4.99',
+            'typo3' => '11.5.0-14.99.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
## Summary
- Bumps `typo3/cms-core` constraint to `^13.4 || ^14.0` and PHP minimum to `^8.2`
- No code changes — the extension only touches generic PHP / Guzzle / `$GLOBALS['TYPO3_CONF_VARS']`, all API-compatible across the supported range

This is a backwards-incompatible release (drops v11 / v12 from the constraint), so tag accordingly (3.0.0).

## Context
Sister PR over at [b13/proxycachemanager#49](https://github.com/b13/proxycachemanager/pull/49) — same support window (^13.4 || ^14.0), but with real v14 code adaptations. Both PRs are needed so b13.com (currently on TYPO3 14.3) can wire up the existing TAE-style Cloudflare CDN integration.

## Test plan
- [ ] `composer require b13/cloudflare-cdn:dev-feature/typo3-v14-support` resolves on a v14 install
- [ ] Manual: configure a zone via `EXTENSIONS.cloudflare.zones` + `CLOUDFLARE_API_TOKEN`, trigger a purge, verify Cloudflare logs